### PR TITLE
Clear polluted state to avoid flaky tests.

### DIFF
--- a/riemann/tests/tx/test_tx_builder.py
+++ b/riemann/tests/tx/test_tx_builder.py
@@ -14,6 +14,7 @@ class TestTxBuilder(unittest.TestCase):
         riemann.select_network('bitcoin_main')
 
     def test_make_sh_output_script(self):
+        riemann.select_network('bitcoin_main')
         self.assertEqual(
             tb.make_sh_output_script('OP_IF'),
             helpers.OP_IF['output_script'])


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `riemann/tests/tx/test_tx_builder.py::TestTxBuilder::test_make_sh_output_script`, which can fail after running `riemann/tests/tx/test_overwinter.py::OverwinterSighash::test_sighash`, but passes when it is run in isolation.

# Reproduce the test failure
Run the following command:
```
python3 -m pytest riemann/tests/tx/test_overwinter.py::OverwinterSighash::test_sighash riemann/tests/tx/test_tx_builder.py::TestTxBuilder::test_make_sh_output_script
```

# Expected Result
`riemann/tests/tx/test_tx_builder.py::TestTxBuilder::test_make_sh_output_script` should pass after running `riemann/tests/tx/test_overwinter.py::OverwinterSighash::test_sighash`.

# Actual result
We get the following error:
```
        if witness and not riemann.network.SEGWIT:
>           raise ValueError(
                'Network {} does not support witness scripts.'
                .format(riemann.get_current_network_name()))
E           ValueError: Network zcash_overwinter_main does not support witness scripts.

riemann/tx/tx_builder.py:46: ValueError
```
# Why it fails

# Fix 